### PR TITLE
Remove unnecessary "depends-on" from Cask

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,8 +3,5 @@
 
 (package-file "keyset.el")
 
-(depends-on "cl-lib")
-(depends-on "dash")
-
 (development
  (depends-on "ert-runner"))


### PR DESCRIPTION
These lines are redundant, since Cask reads the `Package-Requires` header in the file specified by `package-file`.

(This is in connection with https://github.com/milkypostman/melpa/pull/2149)
